### PR TITLE
Update the base image to Ubuntu 20.04 so that it could be used for both amd64 and arm64 images

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -1,0 +1,56 @@
+name: Upload Docker images
+
+permissions:
+  packages: write      
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set variables
+        id: vars
+        run: echo "::set-output name=date_tag::$(date +%y%m%d-%H%M)"
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
+
+      - name: Build and push build-su2
+        uses: docker/build-push-action@v2
+        with:
+          context: build
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/su2code/build-su2:${{ steps.vars.outputs.date_tag }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push test-su2
+        uses: docker/build-push-action@v2
+        with:
+          context: test
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2code/build-su2:${{ steps.vars.outputs.date_tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/su2code/test-su2:${{ steps.vars.outputs.date_tag }}
+          platforms: linux/amd64,linux/arm64

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,11 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+LABEL org.opencontainers.image.source https://github.com/su2code/Docker-Builds
+
 ENV LANG C.UTF-8
-RUN apt-get update && apt-get install -y \
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    apt-utils \
     python3 \
     pkg-config \
     python3-pip \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,8 @@
-FROM su2code/build-su2:latest
+ARG BASE_IMAGE=su2code/build-su2:latest
+
+FROM $BASE_IMAGE
+
+LABEL org.opencontainers.image.source https://github.com/su2code/Docker-Builds
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY runTests.sh /runTests.sh


### PR DESCRIPTION
Set localtime to UTC so that the installation of tzdata do not ask for
selection.