### PR TITLE
Rename the package to 'su2'

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -41,7 +41,7 @@ jobs:
         run: docker buildx create --use
 
       - name: Build and push build-su2
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push .
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push ./build/
 
       - name: Build and push test-su2
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   docker:

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
-    branches:
-      - 'master'
 
 jobs:
   docker:
@@ -44,11 +41,4 @@ jobs:
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push ./build/
 
       - name: Build and push test-su2
-        uses: docker/build-push-action@v2
-        with:
-          context: test
-          push: true
-          build-args: |
-            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }}
-          tags: ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ steps.vars.outputs.date_tag }}
-          platforms: linux/amd64,linux/arm64
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ steps.vars.outputs.date_tag }} --push ./test/

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: build
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/su2code/build-su2:${{ steps.vars.outputs.date_tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }}
           platforms: linux/amd64,linux/arm64
 
       - name: Build and push test-su2
@@ -51,6 +51,6 @@ jobs:
           context: test
           push: true
           build-args: |
-            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2code/build-su2:${{ steps.vars.outputs.date_tag }}
-          tags: ghcr.io/${{ github.repository_owner }}/su2code/test-su2:${{ steps.vars.outputs.date_tag }}
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ steps.vars.outputs.date_tag }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -41,12 +41,7 @@ jobs:
         run: docker buildx create --use
 
       - name: Build and push build-su2
-        uses: docker/build-push-action@v2
-        with:
-          context: build
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }}
-          platforms: linux/amd64,linux/arm64
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push .
 
       - name: Build and push test-su2
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Trying to fix
https://github.com/su2code/Docker-Builds/runs/6294621678?check_suite_focus=true :

error: failed to solve: ghcr.io/su2code/su2code/build-su2:220504-1749: failed to copy: httpReadSeeker: failed open: unexpected status code https://ghcr.io/v2/su2code/su2code/build-su2/blobs/sha256:acfa7418dcbda0c50041afdba1c84fcf7ba58ebc33f5750f2a67fc159f656d53: 403 Forbidden - Server message: denied: permission_denied: read_package
Error: buildx failed with: error: failed to solve: ghcr.io/su2code/su2code/build-su2:220504-1749: failed to copy: httpReadSeeker: failed open: unexpected status code https://ghcr.io/v2/su2code/su2code/build-su2/blobs/sha256:acfa7418dcbda0c50041afdba1c84fcf7ba58ebc33f5750f2a67fc159f656d53: 403 Forbidden - Server message: denied: permission_denied: read_package

At the moment there is a package at
https://github.com/su2code/SU2/pkgs/container/SU2%2Fbuild-su2 that can
be pulled with:

    docker pull ghcr.io/su2code/su2/build-su2:latest

Maybe the failed 'read_package' is because of the mismatch in the names:
'su2code' vs. 'su2'