### PR TITLE
The Docker image for cross build should depend on the latest su2/build-su2 image

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Build and push test-su2
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ steps.vars.outputs.date_tag }} --push ./test/
+
+      - name: Build and push build-su2-cross
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross:${{ steps.vars.outputs.date_tag }} --push ./build_cross/

--- a/build_cross/Dockerfile
+++ b/build_cross/Dockerfile
@@ -1,4 +1,6 @@
-FROM su2code/build-su2:latest
+ARG BASE_IMAGE=ghcr.io/su2code/su2/build-su2:220614-1237
+FROM $BASE_IMAGE
+
 ENV LANG C.UTF-8
 RUN apt-get update && apt-get install -y \
     clang \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=su2code/build-su2:latest
+ARG ghcr.io/su2code/su2/build-su2:220614-1237
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
`release management` fails due to old version of GCC: https://github.com/su2code/SU2/runs/7125551739?check_suite_focus=true

The build-cross-su2 image should extend from latest ghcr.io/su2code/su2/build-su2.

Update the default `FROM` value for the test-su2 image for easier local builds. 