### PR TITLE
Split build_cross/Dockerfile into two

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -9,8 +9,10 @@ on:
       - 'master'
 
 jobs:
-  docker:
+  build-su2:
     runs-on: ubuntu-latest
+    outputs:
+      date_tag: ${{ steps.vars.outputs.date_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,8 +42,89 @@ jobs:
       - name: Build and push build-su2
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push ./build/
 
+  test-su2:
+    needs: [build-su2]
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
+
       - name: Build and push test-su2
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ steps.vars.outputs.date_tag }} --push ./test/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ needs.build-su2.outputs.date_tag }} --push ./test/
+
+  cross-build-su2-mac:
+    needs: [build-su2]
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
 
       - name: Build and push build-su2-cross
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross:${{ steps.vars.outputs.date_tag }} --push ./build_cross/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.build-su2.outputs.date_tag }} --push --file Dockerfile.stage1 ./build_cross/
+
+  cross-build-su2-linux:
+    needs: [cross-build-su2-mac]
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
+
+      - name: Build and push build-su2-cross
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross:${{ needs.build-su2.outputs.date_tag }} --push --file Dockerfile.stage2 ./build_cross/

--- a/build_cross/Dockerfile.stage1
+++ b/build_cross/Dockerfile.stage1
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     mingw-w64
 
 # Get the osxcross tool
-RUN git clone https://github.com/tpoechtrager/osxcross && cd osxcross 
+RUN git clone https://github.com/tpoechtrager/osxcross && cd osxcross
 
 # Copy the OSX sdk
 COPY MacOSX10.15.sdk.tar.xz /osxcross/tarballs/MacOSX10.15.sdk.tar.xz
@@ -28,7 +28,7 @@ RUN cd osxcross && UNATTENDED=1 ./build.sh
 COPY msmpi_v10.1.2.tar.gz /msmpi_v10.1.2.tar.gz
 RUN tar xzf msmpi_v10.1.2.tar.gz
 
-# Copy hostfiles 
+# Copy hostfiles
 COPY hostfiles /hostfiles
 
 # Copy the mpich script
@@ -37,10 +37,7 @@ COPY download_compile_mpich.sh /download_compile_mpich.sh
 ENV PATH /osxcross/target/bin:$PATH
 
 # Compile MPICH for darwin
-RUN sh download_compile_mpich.sh 3.3.2 x86_64-apple-darwin19 
-
-# Compile MPICH for linux
-RUN LDFLAGS=" -static -static-libstdc++ -static-libgcc" sh download_compile_mpich.sh 3.3.2 x86_64-linux-gnu
+RUN sh download_compile_mpich.sh 3.3.2 x86_64-apple-darwin19
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/compileSU2.sh"]

--- a/build_cross/Dockerfile.stage2
+++ b/build_cross/Dockerfile.stage2
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+# Compile MPICH for linux
+RUN LDFLAGS=" -static -static-libstdc++ -static-libgcc" sh download_compile_mpich.sh 3.3.2 x86_64-linux-gnu
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/compileSU2.sh"]


### PR DESCRIPTION
This way the final image build could be split in two CI jobs, each with
timeout of 6 hours.
This is needed because otherwise the Docker image build takes too long
and Github Actions CI stops it.

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>