### PR TITLE
Include packages for python fsi interface

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,6 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     libopenblas-dev \
     openmpi-bin \
     ccache \
+    petsc-dev \
+    python3-petsc4py \
+    python3-rtree \
  && rm -rf /var/lib/apt/lists/* \
  && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
  && /usr/sbin/update-ccache-symlinks \


### PR DESCRIPTION
Dear all,

I am planning to add a regression test on the python interface for fsi. This requires additional packages on the docker build side. I added the packages here, but I am not familiar with the containers use, so let me know if I should proceed otherwise