### PR TITLE
Add containers for building and testing SU2 with the thread sanitizer

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build and push build-su2
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push ./build/
 
+      - name: Build and push build-su2-tsan
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ steps.vars.outputs.date_tag }} --push --file ./build/Dockerfile.tsan ./build/
+
   test-su2:
     needs: [build-su2]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
@@ -70,6 +73,9 @@ jobs:
 
       - name: Build and push test-su2
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ needs.build-su2.outputs.date_tag }} --push ./test/
+
+      - name: Build and push test-su2-tsan
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2-tsan:${{ needs.build-su2.outputs.date_tag }} --push ./test/
 
   cross-build-su2-mac:
     needs: [build-su2]

--- a/build/Dockerfile.tsan
+++ b/build/Dockerfile.tsan
@@ -1,0 +1,67 @@
+FROM ubuntu:20.04
+
+LABEL org.opencontainers.image.source https://github.com/su2code/Docker-Builds
+
+ENV LANG C.UTF-8
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    apt-utils \
+    python3 \
+    pkg-config \
+    python3-pip \
+    git \
+    build-essential \
+    cmake \
+    python3-numpy \
+    python3-scipy \
+    python3-mpi4py \
+    swig \
+    libopenmpi-dev \
+    libopenblas-dev \
+    openmpi-bin \
+    ccache \
+    petsc-dev \
+    python3-petsc4py \
+    python3-rtree \
+    curl \
+    flex \
+    gcc-multilib \
+    g++-multilib \
+ && rm -rf /var/lib/apt/lists/* \
+ && update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+# Build a gcc suitable for thread sanitizer analysis
+RUN cd / \
+ && git clone git://gcc.gnu.org/git/gcc.git gcc_sources \
+ && cd gcc_sources \
+ && git checkout releases/gcc-9.4.0 \
+ && ./contrib/download_prerequisites \
+ && cd / \
+ && mkdir gcc_objdir \
+ && cd gcc_objdir \
+ && /gcc_sources/configure --prefix=/gcc_install --enable-languages=c,c++ --disable-linux-futex \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf gcc_sources \
+ && rm -rf gcc_objdir \
+ && cd /gcc_install \
+ && ln -s gcc cc
+ 
+# Ensure that ccache uses the built gcc
+RUN export PATH=/gcc_install/bin:$PATH \
+ && /usr/sbin/update-ccache-symlinks
+
+# Configure environment for the built gcc, also enable thread sanitizer
+ENV LD_LIBRARY_PATH=/gcc_install/lib64:$LD_LIBRARY_PATH
+ENV CXXFLAGS="-I/gcc_install/include/c++/9.4.0 -I/gcc_install/include/c++/9.4.0/x86_64-pc-linux-gnu -fsanitize=thread"
+ENV CFLAGS="-I/gcc_install/include/c++/9.4.0 -I/gcc_install/include/c++/9.4.0/x86_64-pc-linux-gnu -fsanitize=thread"
+ENV LDFLAGS="-L/gcc_install/lib64 -fsanitize=thread"
+ENV PATH=/usr/lib/ccache:/gcc_install/bin:$PATH
+ENV TSAN_OPTIONS="history_size=7 halt_on_error=1"
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY compileSU2.sh /compileSU2.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/compileSU2.sh"]

--- a/build/Dockerfile.tsan
+++ b/build/Dockerfile.tsan
@@ -25,8 +25,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     python3-rtree \
     curl \
     flex \
-    gcc-multilib \
-    g++-multilib \
  && rm -rf /var/lib/apt/lists/* \
  && update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
@@ -39,7 +37,7 @@ RUN cd / \
  && cd / \
  && mkdir gcc_objdir \
  && cd gcc_objdir \
- && /gcc_sources/configure --prefix=/gcc_install --enable-languages=c,c++ --disable-linux-futex \
+ && /gcc_sources/configure --prefix=/gcc_install --enable-languages=c,c++ --disable-linux-futex --disable-multilib \
  && make \
  && make install \
  && cd / \

--- a/build/Dockerfile.tsan
+++ b/build/Dockerfile.tsan
@@ -43,7 +43,7 @@ RUN cd / \
  && cd / \
  && rm -rf gcc_sources \
  && rm -rf gcc_objdir \
- && cd /gcc_install \
+ && cd /gcc_install/bin \
  && ln -s gcc cc
  
 # Ensure that ccache uses the built gcc


### PR DESCRIPTION
## Overview

This PR provides a container that can be used for building SU2 with the thread sanitizer. Further steps would be a container for testing with the thread sanitizer, and ultimately running thread sanitizer tests as a part of SU2's CI pipeline. This is work in progress and there are things that need testing, hence the focus on the build container for now.

1) Regarding the workflow in this repo that builds and uploads container images, do the resources of the CI pipeline suffice? The container involves building `gcc` from source, which does take some time.
2) The existing build container and the new build container have common parts, when we know that everything works we could consider unifying them.