### PR TITLE
Split build-su2-tsan into multiple jobs

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -85,14 +85,6 @@ jobs:
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -9,10 +9,19 @@ on:
       - 'master'
 
 jobs:
-  build-su2:
+  date-tag:
     runs-on: ubuntu-latest
     outputs:
       date_tag: ${{ steps.vars.outputs.date_tag }}
+    steps:
+      - name: Set variables
+        id: vars
+        run: echo "::set-output name=date_tag::$(date +%y%m%d-%H%M)"
+
+  build-su2:
+    needs: ['date-tag']
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,21 +41,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set variables
-        id: vars
-        run: echo "::set-output name=date_tag::$(date +%y%m%d-%H%M)"
-
       - name: Docker Buildx Create
         run: docker buildx create --use
 
       - name: Build and push build-su2
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ steps.vars.outputs.date_tag }} --push ./build/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} --push ./build/
 
       - name: Build and push build-su2-tsan
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ steps.vars.outputs.date_tag }} --push --file ./build/Dockerfile.tsan ./build/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} --push --file ./build/Dockerfile.tsan ./build/
 
   test-su2:
-    needs: [build-su2]
+    needs: [date-tag, build-su2]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:
@@ -72,13 +77,13 @@ jobs:
         run: docker buildx create --use
 
       - name: Build and push test-su2
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ needs.build-su2.outputs.date_tag }} --push ./test/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ needs.date-tag.outputs.date_tag }} --push ./test/
 
       - name: Build and push test-su2-tsan
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2-tsan:${{ needs.build-su2.outputs.date_tag }} --push ./test/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2-tsan:${{ needs.date-tag.outputs.date_tag }} --push ./test/
 
   cross-build-su2-mac:
-    needs: [build-su2]
+    needs: [date-tag, build-su2]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:
@@ -104,7 +109,7 @@ jobs:
         run: docker buildx create --use
 
       - name: Build and push build-su2-cross
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.build-su2.outputs.date_tag }} --push --file ./build_cross/Dockerfile.stage1 ./build_cross/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.date-tag.outputs.date_tag }} --push --file ./build_cross/Dockerfile.stage1 ./build_cross/
 
   cross-build-su2-linux:
     needs: [build-su2, cross-build-su2-mac]
@@ -133,4 +138,4 @@ jobs:
         run: docker buildx create --use
 
       - name: Build and push build-su2-cross
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.build-su2.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross:${{ needs.build-su2.outputs.date_tag }} --push --file ./build_cross/Dockerfile.stage2 ./build_cross/
+        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross:${{ needs.date-tag.outputs.date_tag }} --push --file ./build_cross/Dockerfile.stage2 ./build_cross/

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "::set-output name=date_tag::$(date +%y%m%d-%H%M)"
 
   build-su2:
-    needs: ['date-tag']
+    needs: [date-tag]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:
@@ -47,11 +47,70 @@ jobs:
       - name: Build and push build-su2
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} --push ./build/
 
-      - name: Build and push build-su2-tsan
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} --push --file ./build/Dockerfile.tsan ./build/
+  build-su2-tsan-platforms:
+    needs: [date-tag]
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false,
+      matrix:
+        platform: [amd64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
+
+      - name: Build and push single-platform build-su2-tsan
+        run: docker buildx build --platform=linux/${{ matrix.platform }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-${{ matrix.platform }}:${{ needs.date-tag.outputs.date_tag }} --push --file ./build/Dockerfile.tsan ./build/
+
+  build-su2-tsan:
+    needs: [date-tag, build-su2-tsan-platforms]
+    if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Buildx Create
+        run: docker buildx create --use
+
+      - name: Merge single-platform build-su2-tsan images
+        run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-amd64:${{ needs.date-tag.outputs.date_tag }} ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-arm64:${{ needs.date-tag.outputs.date_tag }}
 
   test-su2:
-    needs: [date-tag, build-su2]
+    needs: [date-tag, build-su2, build-su2-tsan]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Overview

The thread-sanitizer enabled containers introduced in #17 take too long to build, building `gcc` takes around three hours and the time limit for an individual job is six hours. We need to build `gcc` for `amd64` and `arm64` and we can't do both it in a single job.

Let's see if this works better.
- We do not build the `build-su2-tsan` container image as part of the `build-su2` job.
- We use different jobs to create single-platform container images for `amd64` and `arm64`.
- Afterwards, we merge the single-platform container images.

I ensured that the same `date_tag` is used throughout the workflow.

## Related work

continues #17 