### PR TITLE
Try workaround for image upload and disable tsan-enabled arm64

### DIFF
--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -66,6 +66,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: --debug
+          driver-opts: image=moby/buildkit:v0.9.1
 
       - name: Login to Github Docker Registry
         uses: docker/login-action@v1

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -163,7 +163,7 @@ jobs:
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-cross-stage1:${{ needs.date-tag.outputs.date_tag }} --push --file ./build_cross/Dockerfile.stage1 ./build_cross/
 
   cross-build-su2-linux:
-    needs: [build-su2, cross-build-su2-mac]
+    needs: [date-tag, build-su2, cross-build-su2-mac]
     if: ${{ always() && !(contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-image-upload.yml
+++ b/.github/workflows/docker-image-upload.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [amd64, arm64]
+        platform: [amd64] # arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +102,8 @@ jobs:
         run: docker buildx create --use
 
       - name: Merge single-platform build-su2-tsan images
-        run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-amd64:${{ needs.date-tag.outputs.date_tag }} ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-arm64:${{ needs.date-tag.outputs.date_tag }}
+        run: docker buildx imagetools create -t ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-amd64:${{ needs.date-tag.outputs.date_tag }}
+        # ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan-arm64:${{ needs.date-tag.outputs.date_tag }}
 
   test-su2:
     needs: [date-tag, build-su2, build-su2-tsan]
@@ -134,7 +135,8 @@ jobs:
         run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2:${{ needs.date-tag.outputs.date_tag }} --push ./test/
 
       - name: Build and push test-su2-tsan
-        run: docker buildx build --platform=linux/amd64 --platform=linux/arm64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2-tsan:${{ needs.date-tag.outputs.date_tag }} --push ./test/
+        run: docker buildx build --platform=linux/amd64 --build-arg BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/su2/build-su2-tsan:${{ needs.date-tag.outputs.date_tag }} -t ghcr.io/${{ github.repository_owner }}/su2/test-su2-tsan:${{ needs.date-tag.outputs.date_tag }} --push ./test/
+        # --platform=linux/arm64
 
   cross-build-su2-mac:
     needs: [date-tag, build-su2]


### PR DESCRIPTION
## Overview

Continues work on tsan-enabled containers.

- The CI successfully builds the `build-su2-tsan-amd64` container image, but the upload to `ghcr.io` fails. It could be related to [this issue](https://github.com/docker/setup-buildx-action/issues/113), so I am trying the suggested workaround.
- Building `gcc` for `arm64` takes longer than six hours. I disable tsan-enabled containers for `arm64` for now.

## Related Work

continues #18