### PR TITLE
Fix ranlib

### DIFF
--- a/build/compileSU2.sh
+++ b/build/compileSU2.sh
@@ -1,14 +1,14 @@
 #!/bin/sh -l
 
 echo "SU2 v7 Docker Compilation Container"
-usage="$(basename "$0") [-h] [-f build_flags] [-b branch_name] 
+usage="$(basename "$0") [-h] [-f build_flags] [-b branch_name]
 where:
     -h  show this help text
     -f  meson build flags (ignored if a directory \"docker_build\" is found at /src/SU2).
     -b  branch name (if not given, existing SU2 directory must be mounted in /src/SU2).
 
 Compiled binaries can be found at /install/. Mount that directory for access.
-Note: If you specify a working directory using the --workdir option for docker, 
+Note: If you specify a working directory using the --workdir option for docker,
       append this directory to all paths above (e.g. use --workdir=/tmp if running in user mode)."
 
 flags=""
@@ -24,7 +24,7 @@ if [ "$#" -ne 0 ]; then
             -f)
                     flags=$2
                     shift 2
-                ;;  
+                ;;
             -b)
                     branch=$2
                     shift 2
@@ -48,7 +48,7 @@ if [ ! -z "$branch" ]; then
     # Remove any previous local repo. For non-ephemeral self-hosted runners
     rm -rf $name
   fi
-  # Clone only the latest commit, without the Git history. It is much faster this way. 
+  # Clone only the latest commit, without the Git history. It is much faster this way.
   git clone --recursive --depth=1 --shallow-submodules https://github.com/su2code/SU2 $name
   cd $name
   git config --add remote.origin.fetch '+refs/pull/*/merge:refs/remotes/origin/refs/pull/*/merge'
@@ -65,10 +65,10 @@ else
 fi
 
 if [ ! -d "docker_build" ]; then
-  ./meson.py docker_build --prefix=$workdir/install $flags
+  ./meson.py setup docker_build --prefix=$workdir/install $flags
 else
   echo "Build Directory found. Ignoring build flags. To set new flags, remove docker_build directory."
-  ./meson.py docker_build --reconfigure $flags
+  ./meson.py setup docker_build --reconfigure $flags
 fi
 
 ./ninja -C docker_build install

--- a/build_cross/hostfiles/hostfile_darwin
+++ b/build_cross/hostfiles/hostfile_darwin
@@ -4,6 +4,7 @@ cpp = '/osxcross/target/bin/o64-clang++'
 ar = '/osxcross/target/bin/x86_64-apple-darwin19-ar'
 strip = '/osxcross/target/bin/x86_64-apple-darwin19-strip'
 pkg-config = '/osxcross/target/bin/x86-apple-darwin19-pkg-config'
+ranlib = '/osxcross/target/bin/x86_64-apple-darwin19-ranlib'
 
 [host_machine]
 system ='darwin'

--- a/build_cross/hostfiles/hostfile_darwin
+++ b/build_cross/hostfiles/hostfile_darwin
@@ -3,7 +3,7 @@ c = '/osxcross/target/bin/o64-clang'
 cpp = '/osxcross/target/bin/o64-clang++'
 ar = '/osxcross/target/bin/x86_64-apple-darwin19-ar'
 strip = '/osxcross/target/bin/x86_64-apple-darwin19-strip'
-pkgconfig = '/osxcross/target/bin/x86-apple-darwin19-pkg-config'
+pkg-config = '/osxcross/target/bin/x86-apple-darwin19-pkg-config'
 
 [host_machine]
 system ='darwin'
@@ -11,5 +11,5 @@ cpu_family = 'x86'
 cpu = 'i386'
 endian = 'little'
 
-[properties]
-cpp_args = [ '-Wno-inconsistent-missing-override' ]
+[built-in options]
+cpp_args = ['-Wno-inconsistent-missing-override']

--- a/build_cross/hostfiles/hostfile_darwin
+++ b/build_cross/hostfiles/hostfile_darwin
@@ -3,13 +3,13 @@ c = '/osxcross/target/bin/o64-clang'
 cpp = '/osxcross/target/bin/o64-clang++'
 ar = '/osxcross/target/bin/x86_64-apple-darwin19-ar'
 strip = '/osxcross/target/bin/x86_64-apple-darwin19-strip'
-pkg-config = '/osxcross/target/bin/x86-apple-darwin19-pkg-config'
+pkg-config = '/osxcross/target/bin/x86_64-apple-darwin19-pkg-config'
 ranlib = '/osxcross/target/bin/x86_64-apple-darwin19-ranlib'
 
 [host_machine]
 system ='darwin'
-cpu_family = 'x86'
-cpu = 'i386'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
 endian = 'little'
 
 [built-in options]

--- a/build_cross/hostfiles/hostfile_darwin_mpi
+++ b/build_cross/hostfiles/hostfile_darwin_mpi
@@ -3,7 +3,7 @@ c = '/osxcross/target/bin/o64-clang'
 cpp = '/osxcross/target/bin/o64-clang++'
 ar = '/osxcross/target/bin/x86_64-apple-darwin19-ar'
 strip = '/osxcross/target/bin/x86_64-apple-darwin19-strip'
-pkgconfig = '/osxcross/target/bin/x86_64-apple-darwin19-pkg-config'
+pkg-config = '/osxcross/target/bin/x86_64-apple-darwin19-pkg-config'
 
 [host_machine]
 system ='darwin'
@@ -11,7 +11,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-L/mpich-x86_64-apple-darwin19/lib', '-lmpi', '-lpmpi']
 c_link_args   = ['-L/mpich-x86_64-apple-darwin19/lib', '-lmpi', '-lpmpi']
 cpp_args      = ['-Wno-inconsistent-missing-override', '-I/mpich-x86_64-apple-darwin19/include']

--- a/build_cross/hostfiles/hostfile_darwin_mpi
+++ b/build_cross/hostfiles/hostfile_darwin_mpi
@@ -4,6 +4,7 @@ cpp = '/osxcross/target/bin/o64-clang++'
 ar = '/osxcross/target/bin/x86_64-apple-darwin19-ar'
 strip = '/osxcross/target/bin/x86_64-apple-darwin19-strip'
 pkg-config = '/osxcross/target/bin/x86_64-apple-darwin19-pkg-config'
+ranlib = '/osxcross/target/bin/x86_64-apple-darwin19-ranlib'
 
 [host_machine]
 system ='darwin'

--- a/build_cross/hostfiles/hostfile_linux
+++ b/build_cross/hostfiles/hostfile_linux
@@ -3,7 +3,7 @@ c = 'x86_64-linux-gnu-gcc'
 cpp = 'x86_64-linux-gnu-g++'
 ar = 'x86_64-linux-gnu-ar'
 strip = 'x86_64-linux-gnu-strip'
-pkgconfig = 'x86_64-linux-gnu-pkg-config'
+pkg-config = 'x86_64-linux-gnu-pkg-config'
 
 [host_machine]
 system ='linux'
@@ -11,7 +11,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-static', '-static-libstdc++']
 
 

--- a/build_cross/hostfiles/hostfile_linux_mpi
+++ b/build_cross/hostfiles/hostfile_linux_mpi
@@ -3,7 +3,7 @@ c = 'x86_64-linux-gnu-gcc'
 cpp = 'x86_64-linux-gnu-g++'
 ar = 'x86_64-linux-gnu-ar'
 strip = 'x86_64-linux-gnu-strip'
-pkgconfig = 'x86_64-linux-gnu-pkg-config'
+pkg-config = 'x86_64-linux-gnu-pkg-config'
 
 [host_machine]
 system ='linux'
@@ -11,7 +11,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-static', '-static-libstdc++', '-static-libgcc', '-L/mpich-x86_64-linux-gnu/lib', '-lmpi', '-lxml2', '-lbacktrace', '-lz', '-lpthread', '-lrt']
 c_link_args   = ['-static', '-static-libstdc++', '-static-libgcc', '-L/mpich-x86_64-linux-gnu/lib', '-lmpi', '-lxml2', '-lbacktrace', '-lz', '-lpthread', '-lrt']
 cpp_args      = ['-Wno-inconsistent-missing-override', '-I/mpich-x86_64-linux-gnu/include']

--- a/build_cross/hostfiles/hostfile_windows
+++ b/build_cross/hostfiles/hostfile_windows
@@ -3,7 +3,7 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
-pkgconfig = 'x86_64-w64-mingw32-pkg-config'
+pkg-config = 'x86_64-w64-mingw32-pkg-config'
 
 [host_machine]
 system ='windows'
@@ -11,7 +11,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-static', '-static-libstdc++']
 
 

--- a/build_cross/hostfiles/hostfile_windows_mpi
+++ b/build_cross/hostfiles/hostfile_windows_mpi
@@ -3,7 +3,7 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
 strip = 'x86_64-w64-mingw32-strip'
-pkgconfig = 'x86_64-w64-mingw32-pkg-config'
+pkg-config = 'x86_64-w64-mingw32-pkg-config'
 
 [host_machine]
 system ='windows'
@@ -11,7 +11,7 @@ cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'
 
-[properties]
+[built-in options]
 cpp_link_args = ['-static', '-static-libstdc++', '-L/MSMPI/Lib/x64','-lmsmpi']
 c_link_args   = ['-L/MSMPI/Lib/x64','-lmsmpi']
 cpp_args      = ['-I/MSMPI/Include/']


### PR DESCRIPTION
The logs of the failed MacOS cross-compile actions @pcarruscag mentioned in su2code/SU2#2531 indicated an issue with `ranlib` during linking. I specify the `ranlib` binary in the MacOS hostfiles like we do for the other binaries, which seems to let the compilation finish when I run `compileSU2.sh` in the `build-su2-cross` docker container locally. 

I also suppressed a few deprecation warnings.
